### PR TITLE
Remove `export=` once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.egg-info
+__pycache__
+*.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ after_failure:
 - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
 - chmod +x send.sh
 - ./send.sh failure $WEBHOOK_URL
+before_script: pip install -e .
 script: curl -fLs https://raw.githubusercontent.com/tomviner/run-tests.github.com/fix-run-tests/run.sh | bash -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ after_failure:
 - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
 - chmod +x send.sh
 - ./send.sh failure $WEBHOOK_URL
-script: curl -fLs https://run-tests.github.io | bash -s
+script: curl -fLs https://raw.githubusercontent.com/tomviner/run-tests.github.com/fix-run-tests/run.sh | bash -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ after_failure:
 - chmod +x send.sh
 - ./send.sh failure $WEBHOOK_URL
 before_script: pip install -e .
-script: curl -fLs https://raw.githubusercontent.com/tomviner/run-tests.github.com/fix-run-tests/run.sh | bash -s
+script: curl -fLs https://run-tests.github.io | bash -s

--- a/env_file/__init__.py
+++ b/env_file/__init__.py
@@ -12,7 +12,7 @@ def parse(line):
         return {}
     """find the second occurence of a quote mark:"""
     if line.find("export=") == 0:
-        line = line.replace("export=", "")
+        line = line.replace("export=", "", 1)
     quote_delimit = max(line.find('\'', line.find('\'') + 1),
                         line.find('"', line.rfind('"')) + 1)
     """find first comment mark after second quote mark"""

--- a/env_file/__init__.py
+++ b/env_file/__init__.py
@@ -11,8 +11,8 @@ def parse(line):
     if not line.lstrip():
         return {}
     """find the second occurence of a quote mark:"""
-    if line.find("export=") == 0:
-        line = line.replace("export=", "", 1)
+    if line.find("export ") == 0:
+        line = line.replace("export ", "", 1)
     quote_delimit = max(line.find('\'', line.find('\'') + 1),
                         line.find('"', line.rfind('"')) + 1)
     """find first comment mark after second quote mark"""

--- a/tests/env_file/.env
+++ b/tests/env_file/.env
@@ -7,3 +7,4 @@ POSTGRES_PASSWORD=secret
 SINGLE_QUOTED='value'
 DOUBLE_QUOTED="value"
 export=EXPORTED=value
+export=CONTAINS_EXPORT='key=value; export=more'

--- a/tests/env_file/.env
+++ b/tests/env_file/.env
@@ -3,3 +3,7 @@ POSTGRES_DB=workout
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=secret
 
+# COMMENT=1
+SINGLE_QUOTED='value'
+DOUBLE_QUOTED="value"
+export=EXPORTED=value

--- a/tests/env_file/.env
+++ b/tests/env_file/.env
@@ -6,5 +6,5 @@ POSTGRES_PASSWORD=secret
 # COMMENT=1
 SINGLE_QUOTED='value'
 DOUBLE_QUOTED="value"
-export=EXPORTED=value
-export=CONTAINS_EXPORT='key=value; export=more'
+export EXPORTED=value
+export CONTAINS_EXPORT='key=value; export more'

--- a/tests/env_file/get.py
+++ b/tests/env_file/get.py
@@ -9,3 +9,8 @@ print(data)
 
 assert data["PGDATA"] == "/var/lib/postgresql/data"
 assert data["POSTGRES_USER"] == "postgres"
+
+assert 'COMMENT' not in data
+assert data["SINGLE_QUOTED"] == "value"
+assert data["DOUBLE_QUOTED"] == "value"
+assert data["EXPORTED"] == "value"

--- a/tests/env_file/get.py
+++ b/tests/env_file/get.py
@@ -14,4 +14,4 @@ assert 'COMMENT' not in data
 assert data["SINGLE_QUOTED"] == "value"
 assert data["DOUBLE_QUOTED"] == "value"
 assert data["EXPORTED"] == "value"
-assert data["CONTAINS_EXPORT"] == "key=value; export=more"
+assert data["CONTAINS_EXPORT"] == "key=value; export more"

--- a/tests/env_file/get.py
+++ b/tests/env_file/get.py
@@ -14,3 +14,4 @@ assert 'COMMENT' not in data
 assert data["SINGLE_QUOTED"] == "value"
 assert data["DOUBLE_QUOTED"] == "value"
 assert data["EXPORTED"] == "value"
+assert data["CONTAINS_EXPORT"] == "key=value; export=more"

--- a/tests/env_file/load.py
+++ b/tests/env_file/load.py
@@ -6,6 +6,6 @@ os.chdir(os.path.dirname(__file__))
 
 env_file.load()
 env_file.load(".env")
-env_file.load([".env","dev.env"])
+env_file.load([".env", "dev.env"])
 for var, value in os.environ.items():
-    print("%s=%s" % (var,value))
+    print("%s=%s" % (var, value))


### PR DESCRIPTION
This PR was intended to fix a minor issue and in the process found the test running script wasn't running the tests for a couple reasons.

The minor issue:
- if an env var happened to contain, in the middle, the string `export=`, it would be removed. Bit of a low risk, but might as well fix it.

In the process, I wrote a failing test, however travis-ci went green, and I discovered [this issue in `run-tests.github.com`](https://github.com/run-tests/run-tests.github.com/pull/1).

Having found a fix for that, and temporarily pulling the test script from my fixed version, I then noticed we needed to install the requirements. I thought it might be nice to [mention this in the docs](https://github.com/run-tests/run-tests.github.com/pull/2), as at least this repo made that oversight.

I also added a few more test cases.

*Update:* I've just realised, should the string that's removed be `export<space>` not `export=`? I've made that change.