### PR TITLE
Ignore .env lines that do not have key=value assignment.

### DIFF
--- a/env_file/__init__.py
+++ b/env_file/__init__.py
@@ -11,6 +11,8 @@ def parse(line):
         return {}
     if not line.lstrip():
         return {}
+    if not "=" in line:
+        return {}
     """find the second occurence of a quote mark:"""
     if line.find("export ") == 0:
         line = line.replace("export ", "", 1)

--- a/tests/env_file/.env
+++ b/tests/env_file/.env
@@ -8,3 +8,7 @@ SINGLE_QUOTED='value'
 DOUBLE_QUOTED="value"
 export EXPORTED=value
 export CONTAINS_EXPORT='key=value; export more'
+
+# https://direnv.net/man/direnv-stdlib.1.html syntax has lines that are not
+# key-value pairs -- ignore lines without an equal sign
+layout python python3


### PR DESCRIPTION
The (direnv)[https://pypi.org/project/direnv/] module uses env-file to
load its config files. The (direnv configuration
syntax)[https://direnv.net/man/direnv-stdlib.1.html] does not require
key=value pairs for certain directives.

If env_file encounters lines that do not do key=value
assignments (test for presence of "="), skip those lines.